### PR TITLE
Draft: feat: add protobuf generate flow

### DIFF
--- a/cue/types.go
+++ b/cue/types.go
@@ -546,6 +546,8 @@ type Value struct {
 	parent_ *parent
 }
 
+func (v Value) Vertex() *adt.Vertex { return v.v }
+
 // parent is a distinct type from Value to ensure more type safety: Value
 // is typically used by value, so taking a pointer to it has a high risk
 // or globbering the contents.

--- a/encoding/protobuf/testdata/example.cue
+++ b/encoding/protobuf/testdata/example.cue
@@ -1,0 +1,24 @@
+package example
+
+#person: {
+	// Shit gets fucked when optional/required
+	name: string
+	age:  int
+}
+
+#address: {
+	country: string
+}
+
+#person_address: {
+	thing: #person
+	other: #address
+}
+
+data: {
+	name: "cueckoo"
+}
+
+_hidden: {
+	value: 5
+}

--- a/encoding/protobuf/testdata/example.proto
+++ b/encoding/protobuf/testdata/example.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+message person {
+	string name = 1;
+	int32 age = 2;
+}
+message address {
+	string country = 1;
+}
+message person_address {
+	person thing = 1;
+	address other = 2;
+}


### PR DESCRIPTION
Heyo, this is my initial super primitive stab at exploring how to approach on how to perform `.proto` file generation from a Cue schema.

## Why am I going down this route
- We want to be able to ingest concrete configuration into multiple different environments all using different languages.
- To be able to do that now, we have to write a yaml parser and the types in each respective language.
-  Leveraging something like Protobufs allows us to have a lingua franca and generate serializers/deserializers of such configuration
- Those Types are defined as Cue definitions and a `Generate()` for `encoding/protobuf` would allow for automatic maintenance of protobuf definitions.

Whats missing here is maybe some step of auto generating a tool that can take some concrete configuration and convert it to protobuf _messages_ using the generated protobuf files.

## Where I need help
I am still a bit of a Go noob, but @b4nst has offered to help out.

I could use help though from the Cue community to understand what the best patterns may be for accomplishing my goals.  I've made an attempt here but it has required opening up the API, which leads me to believe it's not the most intended pattern.